### PR TITLE
Add storeId workaround tests for cookies.getAll() (FB23657073)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Observed in Safari with a temporary extension: after setting cookies from
 `https://setcookie.net/`, both `cookies.getAll({url})` and `cookies.getAll({domain})`
 returned `(none)`. In Firefox, both calls returned the JavaScript-visible test cookies.
 
+Workaround: enumerating cookie stores with `cookies.getAllCookieStores()` and passing
+an explicit `storeId` to `cookies.getAll()` returns the expected cookies. Safari
+reported two stores: `persistent-1` (the default data store, 0 cookies, no tabs) and
+`persistent-2` (the browsing session's store, with all browser cookies and the open
+tabs in `tabIds`). Calls without `storeId` -- including unfiltered
+`cookies.getAll({})` -- returned nothing even after successful `storeId` queries, so
+omitting `storeId` queries the empty default store rather than the store of the
+browsing session. Since store IDs other than `persistent-1` are runtime-generated
+session IDs, an extension has to select the store dynamically, e.g. by finding the
+store whose `tabIds` contains the relevant tab.
+
 ##### `browser.i18n.getMessage()` corrupts quoted positional placeholders (FB23657112)
 
 Test button: `Test i18n Placeholders (FB23657112)`

--- a/background/cookie-test.js
+++ b/background/cookie-test.js
@@ -12,6 +12,10 @@ function getCookies(details) {
 	return new Promise((resolve) => chrome.cookies.getAll(details, resolve));
 }
 
+function getCookieStores() {
+	return new Promise((resolve) => chrome.cookies.getAllCookieStores(resolve));
+}
+
 function removeCookie(details) {
 	return new Promise((resolve) => chrome.cookies.remove(details, resolve));
 }
@@ -96,16 +100,64 @@ async function testCookieRetrieval() {
 		let testRun = createCookieTestRun();
 		await setBrowserCookies(testRun);
 
+		let matchesTestCookie = (cookie) => cookie.name === COOKIE_RETRIEVAL_NAME && cookie.value === testRun.retrievalValue;
+
 		let byUrl = await getCookies({url: COOKIE_TEST_URL});
 		let byDomain = await getCookies({domain: 'setcookie.net'});
-		let expectedByUrl = byUrl.some((cookie) => cookie.name === COOKIE_RETRIEVAL_NAME && cookie.value === testRun.retrievalValue);
-		let expectedByDomain = byDomain.some((cookie) => cookie.name === COOKIE_RETRIEVAL_NAME && cookie.value === testRun.retrievalValue);
 
 		logCookieNames('cookies.getAll({url}) returned', byUrl);
-		console.log(`cookies.getAll({url}) result: ${formatTestResult(expectedByUrl)}`);
+		console.log(`cookies.getAll({url}) result: ${formatTestResult(byUrl.some(matchesTestCookie))}`);
 
 		logCookieNames('cookies.getAll({domain}) returned', byDomain);
-		console.log(`cookies.getAll({domain}) result: ${formatTestResult(expectedByDomain)}`);
+		console.log(`cookies.getAll({domain}) result: ${formatTestResult(byDomain.some(matchesTestCookie))}`);
+
+		console.log('Testing workaround: cookies.getAll() with explicit storeId for each cookie store');
+		let stores;
+		try {
+			stores = await withTimeout(getCookieStores(), 5000, 'cookies.getAllCookieStores()');
+		}
+		catch (e) {
+			console.log(`cookies.getAllCookieStores() failed: ${e.message}`);
+			stores = null;
+		}
+
+		if (!stores || !stores.length) {
+			console.log(`cookies.getAllCookieStores() returned ${stores ? 'no stores' : 'nothing'}`);
+			console.log(`cookies.getAll({url, storeId}) result: ${formatTestResult(false)}`);
+			console.log(`cookies.getAll({domain, storeId}) result: ${formatTestResult(false)}`);
+		}
+		else {
+			console.log(`cookies.getAllCookieStores() returned ${stores.length} store(s): ${stores.map((store) => `${store.id} (tabIds: [${store.tabIds ? store.tabIds.join(', ') : ''}])`).join(', ')}`);
+
+			let byUrlWithStore = [];
+			let byDomainWithStore = [];
+			for (let store of stores) {
+				let storeCookies = await getCookies({storeId: store.id});
+				console.log(`cookies.getAll({storeId: '${store.id}'}) returned ${storeCookies.length} cookie(s) total`);
+				let urlCookies = await getCookies({url: COOKIE_TEST_URL, storeId: store.id});
+				logCookieNames(`cookies.getAll({url, storeId: '${store.id}'}) returned`, urlCookies);
+				byUrlWithStore.push(...urlCookies);
+				byDomainWithStore.push(...await getCookies({domain: 'setcookie.net', storeId: store.id}));
+			}
+
+			logCookieNames('cookies.getAll({url, storeId}) returned', byUrlWithStore);
+			console.log(`cookies.getAll({url, storeId}) result: ${formatTestResult(byUrlWithStore.some(matchesTestCookie))}`);
+
+			logCookieNames('cookies.getAll({domain, storeId}) returned', byDomainWithStore);
+			console.log(`cookies.getAll({domain, storeId}) result: ${formatTestResult(byDomainWithStore.some(matchesTestCookie))}`);
+		}
+
+		console.log('Testing workaround: unfiltered cookies.getAll({}) with manual filtering');
+		let allCookies = await getCookies({});
+		console.log(`cookies.getAll({}) returned ${allCookies.length} cookie(s)`);
+		let manuallyFiltered = allCookies.filter((cookie) => cookie.domain && cookie.domain.replace(/^\./, '').endsWith('setcookie.net'));
+		logCookieNames('cookies.getAll({}) filtered to setcookie.net', manuallyFiltered);
+		console.log(`cookies.getAll({}) manual filter result: ${formatTestResult(manuallyFiltered.some(matchesTestCookie))}`);
+
+		console.log('Testing workaround: retrying plain cookies.getAll() after the calls above');
+		let byUrlRetry = await getCookies({url: COOKIE_TEST_URL});
+		logCookieNames('cookies.getAll({url}) retry returned', byUrlRetry);
+		console.log(`cookies.getAll({url}) retry result: ${formatTestResult(byUrlRetry.some(matchesTestCookie))}`);
 	}
 	finally {
 		await clearBrowserCookies();


### PR DESCRIPTION
## Summary

Extends the cookie retrieval test with workaround variants for the `cookies.getAll()` issue (FB23657073) and documents the findings in the README.

New checks after the existing baseline `getAll({url})`/`getAll({domain})` calls:

- `getAllCookieStores()` + `getAll({..., storeId})` for each store, with per-store total cookie counts and `tabIds`
- Unfiltered `getAll({})` with manual domain filtering
- A plain `getAll({url})` retry at the end, to rule out a warm-up/first-call explanation

## Results in Safari 26

- `persistent-1` (the default data store) has **0 cookies** and no tabs; every call that omits `storeId` — including unfiltered `getAll({})` — queries this store and returns nothing.
- `persistent-2` (the browsing session's store) holds all browser cookies (909 in testing) and lists the open tabs in `tabIds`; passing its `storeId` returns the expected cookies.
- The retry still fails after successful `storeId` queries, so this is not the first-launch/network-process issue fixed upstream in [WebKit bug 315310](https://bugs.webkit.org/show_bug.cgi?id=315310) — calls without `storeId` are bound to a different store entirely.

## Interpretation

In the WebKit source, an omitted `storeId` resolves to the extension controller's default website data store ([WebExtensionContextAPICookiesCocoa.mm](https://github.com/WebKit/WebKit/blob/main/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm)), and in Safari 26 that's evidently not the data store browsing tabs use. The documented behavior for an omitted `storeId` is to use "the current execution context's cookie store" ([MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll)), so if the extension's own context runs in the default data store, this may be technically consistent with the docs — but in Chrome and Firefox the extension context shares the browsing profile's store, so the same rule returns the browser's cookies there. In Safari the effect is that `getAll()` without `storeId` can't return cookies for any website. Whether the store association is intended or not, extensions need to resolve the store explicitly, e.g. by matching `tabIds` against the relevant tab, and store ids other than `persistent-1` are runtime-generated (`SessionID::generatePersistentSessionID()` is a per-launch counter), so they can't be hard-coded.

## Test output (Safari 26, temporary extension)

```
cookies.getAll({url}) returned: (none)                                  ❌
cookies.getAll({domain}) returned: (none)                               ❌
cookies.getAllCookieStores(): persistent-1 (tabIds: []),
                              persistent-2 (tabIds: [2329127, ...])
cookies.getAll({storeId: 'persistent-1'}): 0 cookie(s) total
cookies.getAll({storeId: 'persistent-2'}): 909 cookie(s) total
cookies.getAll({url, storeId: 'persistent-2'}): safariTestCookieRetrieval ✅
cookies.getAll({domain, storeId}): safariTestCookieRetrieval            ✅
cookies.getAll({}) returned 0 cookie(s)                                 ❌
cookies.getAll({url}) retry returned: (none)                            ❌
```